### PR TITLE
Add precision tuning for more even distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "nan": "2.10.0"
   },
   "devDependencies": {
+    "chi-squared-test": "^1.1.0",
     "mocha": "^2.3.2"
   },
   "bugs": {

--- a/src/hash_ring.cc
+++ b/src/hash_ring.cc
@@ -11,7 +11,7 @@ using namespace v8;
 using namespace node;
 using namespace Nan;
 
-uint32_t DEFAULT_PRECISION = 1000;
+uint32_t DEFAULT_PRECISION = 40;
 
 void HashRing::hash_digest(char *in, unsigned char out[16]) {
     md5_state_t md5_state;

--- a/src/hash_ring.cc
+++ b/src/hash_ring.cc
@@ -11,6 +11,8 @@ using namespace v8;
 using namespace node;
 using namespace Nan;
 
+uint32_t DEFAULT_PRECISION = 1000;
+
 void HashRing::hash_digest(char *in, unsigned char out[16]) {
     md5_state_t md5_state;
     md5_init(&md5_state);
@@ -43,7 +45,7 @@ NAN_MODULE_INIT(HashRing::Initialize) {
     Nan::Set(target, Nan::New<v8::String>("HashRing").ToLocalChecked(), tpl->GetFunction());
 }
 
-HashRing::HashRing(Local<Object> weight_hash) : Nan::ObjectWrap() {
+HashRing::HashRing(Local<Object> weight_hash, uint32_t precision) : Nan::ObjectWrap() {
     Local<v8::Array> node_names = Nan::GetPropertyNames(weight_hash).ToLocalChecked();
     Local<String> node_name;
     uint32_t weight_total = 0;
@@ -62,12 +64,12 @@ HashRing::HashRing(Local<Object> weight_hash) : Nan::ObjectWrap() {
         weight_total += node->weight;
     }
 
-    Vpoint *vpoint_list = new Vpoint[num_servers * 160];
+    Vpoint *vpoint_list = new Vpoint[num_servers * 4 * precision];
     unsigned int j, k;
     int vpoint_idx = 0;
     for (j = 0; j < num_servers; j++) {
         float percent = (float) node_list[j].weight / (float) weight_total;
-        unsigned int num_replicas = floorf(percent * 40.0 * (float) num_servers);
+        unsigned int num_replicas = floorf(percent * precision * (float) num_servers);
         for (k = 0; k < num_replicas; k++) {
             char ss[30];
             sprintf(ss, "%s-%d", node_list[j].id, k);
@@ -98,7 +100,13 @@ HashRing::~HashRing(){
 NAN_METHOD(HashRing::New) {
     if (info.IsConstructCall() && info.Length() >= 1 && info[0]->IsObject()) {
         Local<Object> weight_hash = info[0]->ToObject();
-        HashRing* hash_ring = new HashRing(weight_hash);
+
+        uint32_t precision = DEFAULT_PRECISION;
+        if (info.Length() >= 2 && info[1]->IsNumber()) {
+          precision = (int) info[1]->Uint32Value();
+        }
+
+        HashRing* hash_ring = new HashRing(weight_hash, precision);
 
         hash_ring->Wrap(info.This());
         info.GetReturnValue().Set(info.This());

--- a/src/hash_ring.h
+++ b/src/hash_ring.h
@@ -13,6 +13,7 @@ typedef struct {
 typedef struct {
     int num_points;
     Vpoint *vpoints;
+    int precision;
 } Ring;
 
 typedef struct {
@@ -25,7 +26,7 @@ class HashRing : public Nan::ObjectWrap {
     Ring ring;
 
   public:
-    explicit HashRing(v8::Local<v8::Object> weight_hash);
+    explicit HashRing(v8::Local<v8::Object> weight_hash, uint32_t precision);
     ~HashRing();
 
     static NAN_MODULE_INIT(Initialize);

--- a/test/test_distribution.js
+++ b/test/test_distribution.js
@@ -16,6 +16,14 @@ describe("hash ring", function() {
     assert.ok(pval > acceptablePVal, `expect pval ${pval} to be > ${acceptablePVal}`);
   });
 
+  it('semi-randomly distributes even weights when no precision passed', function() {
+    const weights = {'a': 1, 'b': 1, 'c': 1};
+    const fn = () => genCode(10);
+
+    const pval = trialPVals(runs, weights, iterations, fn);
+    assert.ok(pval > 0, `expect pval ${pval} to be > 0`);
+  });
+
   it('randomly distributes different weights', function () {
     const weights = {'a': 1, 'b': 1, 'c': 4};
     const fn = () => genCode(10);

--- a/test/test_distribution.js
+++ b/test/test_distribution.js
@@ -1,52 +1,120 @@
-var assert = require('assert');
+const assert = require('assert');
+const chiSquaredTest = require('chi-squared-test');
 
-var HashRing = require("../index");
+const HashRing = require("../index");
 
-var nodes = {
-    "127.0.0.1:8080": 1,
-    "127.0.0.2:8080": 1,
-    "127.0.0.3:8080": 1
-};
-
-var ring = new HashRing(nodes);
-
-var iterations = 100000;
-
-var genCode = function (length) {
-    length = length || 10;
-    var chars = "QWERTYUIOPASDFGHJKLZXCVBNMqwertyuiopasdfghjklzxcvbnm1234567890",
-        numChars = chars.length;
-    var ret = "";
-    for (var i = 0; i < length; i++) {
-        ret += chars[parseInt(Math.random() * numChars, 10)];
-    }
-    return ret;
-};
+const iterations = 10000;
+const runs = 10;
+const acceptablePVal = 0.10;
 
 describe("hash ring", function() {
-  it('should be randomly distributed', function () {
-    var counts = {},
-        node, i, len, word;
-    for (i = 0, len = nodes.length; i < len; i++) {
-        node = nodes[i];
-        counts[node] = 0;
+  it('randomly distributes even weights', function () {
+    const weights = {'a': 1, 'b': 1, 'c': 1};
+    const fn = () => genCode(10);
+
+    const pval = trialPVals(runs, weights, iterations, fn, 1000);
+    assert.ok(pval > acceptablePVal, `expect pval ${pval} to be > ${acceptablePVal}`);
+  });
+
+  it('randomly distributes different weights', function () {
+    const weights = {'a': 1, 'b': 1, 'c': 4};
+    const fn = () => genCode(10);
+
+    const pval = trialPVals(runs, weights, iterations, fn, 1000);
+    assert.ok(pval > acceptablePVal, `expect pval ${pval} to be > ${acceptablePVal}`);
+  });
+
+  it('uses full value when hashing', function () {
+    const weights = {'a': 1, 'b': 1, 'c': 4};
+    const fn = () => '00000000000000' + genCode(10) + '0000000000000';
+
+    const pval = trialPVals(runs, weights, iterations, fn, 1000);
+    assert.ok(pval > acceptablePVal, `expect pval ${pval} to be > ${acceptablePVal}`);
+  });
+
+  it('consistently distributes identical values', function() {
+    const weights = {'a': 1, 'b': 1, 'c': 1};
+
+    const trial = trialPVal(weights, 3000, () => 'hello');
+    assert.equal(trial.counts['b'], 3000, 'all values bucketed the same');
+  });
+
+  it('keeps existing bucket choices when removing buckets', function() {
+    const weights = {'a': 1, 'b': 1, 'c': 1};
+    const ring = new HashRing(weights);
+
+    const bValues = [];
+    for (let i = 0; i < iterations; i++) {
+      const word = genCode(10);
+      const value = ring.getNode(word);
+      if (value === 'b') {
+        bValues.push(word);
+      }
     }
-    for (i = 0, len = iterations; i < len; i++) {
-      word = genCode(10);
-      node = ring.getNode(word);
-      counts[node] = counts[node] || 0;
-      counts[node]++;
-    }
-    var total = Object.keys(counts).reduce( function (sum, node) {
-      return sum += counts[node];
-    }, 0.0);
-    var delta = 0.05
-      , lower = 1.0 / 3 - 0.05
-      , upper = 1.0 / 3 + 0.05;
-    for (node in counts) {
-      var result = (counts[node] / total);
-      assert(result > lower);
-      assert(result < upper);
-    }
+
+    const fewerWeights = {'a': 1, 'b': 1};
+    const fewerRing = new HashRing(weights);
+    const stillBValues = bValues.filter(word => {
+      return fewerRing.getNode(word) === 'b';
+    });
+
+    assert.equal(bValues.length, stillBValues.length, "all 'b' bucket values are still in 'b'");
+
+    const moreWeights = {'a': 1, 'b': 1, 'c': 1, 'd': 1};
+    const moreRing = new HashRing(weights);
+    const stillBorDValues = bValues.filter(word => {
+      const value = moreRing.getNode(word);
+      return value === 'b' || value === 'd';
+    });
+
+    assert.equal(bValues.length, stillBorDValues.length, "all 'b' bucket values are either still in 'b' or are now in 'd'");
   });
 });
+
+function trialPVals(runs, weights, iterations, valueFn, precision) {
+  let pvals = [];
+  for (let i = 0; i < runs; i++) {
+    pvals.push(trialPVal(weights, iterations, valueFn, precision));
+  }
+
+  return average(pvals.map(p => p.probability));
+}
+
+function trialPVal(weights, iterations, valueFn, precision) {
+  const totalWeight = Object.values(weights).reduce((sum, w) => sum += w, 0);
+  const percents = Object.values(weights).map(w => w / totalWeight);
+  const expected = percents.map(p => iterations * p);
+
+  const ring = new HashRing(weights, precision);
+
+  let counts = {};
+  for (let i = 0; i < iterations; i++) {
+    const value = ring.getNode(valueFn());
+    if (!counts[value]) {
+      counts[value] = 0;
+    }
+    counts[value]++;
+  }
+
+  const countList = Object.keys(weights).map(k => counts[k]);
+
+  return {
+    probability: chiSquaredTest(countList, expected, 1).probability,
+    counts
+  };
+}
+
+function average(arr) {
+  return arr.reduce((sum, a) => sum += a, 0) / arr.length;
+}
+
+function genCode (length) {
+  length = length || 10;
+  var chars = "QWERTYUIOPASDFGHJKLZXCVBNMqwertyuiopasdfghjklzxcvbnm1234567890",
+      numChars = chars.length;
+  var ret = "";
+  for (var i = 0; i < length; i++) {
+    ret += chars[parseInt(Math.random() * numChars, 10)];
+  }
+  return ret;
+};

--- a/test/test_distribution.js
+++ b/test/test_distribution.js
@@ -61,7 +61,7 @@ describe("hash ring", function() {
     assert.equal(bValues.length, stillBValues.length, "all 'b' bucket values are still in 'b'");
 
     const moreWeights = {'a': 1, 'b': 1, 'c': 1, 'd': 1};
-    const moreRing = new HashRing(weights);
+    const moreRing = new HashRing(moreWeights);
     const stillBorDValues = bValues.filter(word => {
       const value = moreRing.getNode(word);
       return value === 'b' || value === 'd';

--- a/test/test_distribution.js
+++ b/test/test_distribution.js
@@ -35,13 +35,13 @@ describe("hash ring", function() {
   it('consistently distributes identical values', function() {
     const weights = {'a': 1, 'b': 1, 'c': 1};
 
-    const trial = trialPVal(weights, 3000, () => 'hello');
+    const trial = trialPVal(weights, 3000, () => 'hello', 1000);
     assert.equal(trial.counts['b'], 3000, 'all values bucketed the same');
   });
 
   it('keeps existing bucket choices when removing buckets', function() {
     const weights = {'a': 1, 'b': 1, 'c': 1};
-    const ring = new HashRing(weights);
+    const ring = new HashRing(weights, 1000);
 
     const bValues = [];
     for (let i = 0; i < iterations; i++) {
@@ -53,7 +53,7 @@ describe("hash ring", function() {
     }
 
     const fewerWeights = {'a': 1, 'b': 1};
-    const fewerRing = new HashRing(weights);
+    const fewerRing = new HashRing(weights, 1000);
     const stillBValues = bValues.filter(word => {
       return fewerRing.getNode(word) === 'b';
     });
@@ -61,7 +61,7 @@ describe("hash ring", function() {
     assert.equal(bValues.length, stillBValues.length, "all 'b' bucket values are still in 'b'");
 
     const moreWeights = {'a': 1, 'b': 1, 'c': 1, 'd': 1};
-    const moreRing = new HashRing(moreWeights);
+    const moreRing = new HashRing(moreWeights, 1000);
     const stillBorDValues = bValues.filter(word => {
       const value = moreRing.getNode(word);
       return value === 'b' || value === 'd';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,31 +2,56 @@
 # yarn lockfile v1
 
 
+chi-squared-test@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/chi-squared-test/-/chi-squared-test-1.1.0.tgz#7c00240c6071a6178c42551670fedff3e7bbe442"
+  integrity sha1-fAAkDGBxpheMQlUWcP7f8+e75EI=
+  dependencies:
+    chi-squared "^1.1.0"
+
+chi-squared@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/chi-squared/-/chi-squared-1.1.0.tgz#892865cffa8e0a720f921bfc9c635c19ac2a346d"
+  integrity sha1-iShlz/qOCnIPkhv8nGNcGawqNG0=
+  dependencies:
+    gamma "^1.0.0"
+
 commander@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-0.6.1.tgz#fa68a14f6a945d54dbbe50d8cdb3320e9e3b1a06"
+  integrity sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=
 
 commander@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.3.0.tgz#fd430e889832ec353b9acd1de217c11cb3eef873"
+  integrity sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=
 
 debug@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
+  integrity sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=
   dependencies:
     ms "0.7.1"
 
 diff@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
+  integrity sha1-fyjS657nsVqX79ic5j3P2qPMur8=
 
 escape-string-regexp@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
+  integrity sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=
+
+gamma@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gamma/-/gamma-1.0.0.tgz#983c1c939fe23d932701585711e1d9a430cb74cb"
+  integrity sha1-mDwck5/iPZMnAVhXEeHZpDDLdMs=
 
 glob@3.2.11:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/glob/-/glob-3.2.11.tgz#4a973f635b9190f715d10987d5c00fd2815ebe3d"
+  integrity sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=
   dependencies:
     inherits "2"
     minimatch "0.3"
@@ -34,14 +59,17 @@ glob@3.2.11:
 growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
+  integrity sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=
 
 inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 jade@0.26.3:
   version "0.26.3"
   resolved "https://registry.yarnpkg.com/jade/-/jade-0.26.3.tgz#8f10d7977d8d79f2f6ff862a81b0513ccb25686c"
+  integrity sha1-jxDXl32NefL2/4YqgbBRPMslaGw=
   dependencies:
     commander "0.6.1"
     mkdirp "0.3.0"
@@ -49,10 +77,12 @@ jade@0.26.3:
 lru-cache@2:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
+  integrity sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=
 
 minimatch@0.3:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-0.3.0.tgz#275d8edaac4f1bb3326472089e7949c8394699dd"
+  integrity sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=
   dependencies:
     lru-cache "2"
     sigmund "~1.0.0"
@@ -60,20 +90,24 @@ minimatch@0.3:
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
 mkdirp@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
+  integrity sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=
 
 mkdirp@0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
 
 mocha@^2.3.2:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-2.5.3.tgz#161be5bdeb496771eb9b35745050b622b5aefc58"
+  integrity sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=
   dependencies:
     commander "2.3.0"
     debug "2.2.0"
@@ -89,19 +123,24 @@ mocha@^2.3.2:
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
+  integrity sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=
 
 nan@2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
+  integrity sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==
 
 sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
+  integrity sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=
 
 supports-color@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-1.2.0.tgz#ff1ed1e61169d06b3cf2d588e188b18d8847e17e"
+  integrity sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=
 
 to-iso-string@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/to-iso-string/-/to-iso-string-0.0.2.tgz#4dc19e664dfccbe25bd8db508b00c6da158255d1"
+  integrity sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=


### PR DESCRIPTION
Over the past few months we've noticed that while `node-hash-ring` does a _reasonable_ job at distributing values to nodes, it tends to produce distributions that are somewhat uneven, often around ~5%. This is ok for distributing load between servers, but is undesirable for other applications. (for instance, consistently hashing users for A/B testing)

To correct this, this PR makes the precision tunable. This adds a second argument:

```
const ring = new HashRing({'a': 1, 'b': 2}, 1000);
```

The default `precision` remains unchanged at `40`; in order to get a reasonable distribution a value of ~`1000` or so may be better. We verify with `chi-squared-test`, to ensure that probabilities are consistently `> 0.10`.

This increases both the HashRing memory usage as well as the CPU needed to construct it, but given our use case (lots of values, few nodes, hash rings instantiated in advance) it produces more even results.